### PR TITLE
distributed mnist keras on cmle

### DIFF
--- a/Experimental/distributed_keras/mnist/Keras_MNIST_CMLE.ipynb
+++ b/Experimental/distributed_keras/mnist/Keras_MNIST_CMLE.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run training on CMLE and test the online prediction service\n",
+    "**Assumes preprocessed data is available in GCS**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "REGION = \"\"\n",
+    "TFVERSION = \"1.8\"\n",
+    "BUCKET = \"\"\n",
+    "DATA_DIR = \"\"\n",
+    "MODEL_DIR = \"\"\n",
+    "MODEL_NAME = \"\" # no hyphens in model name\n",
+    "MODEL_VERSION = \"\"\n",
+    "JOBDIR = \"gs://$BUCKET/$MODEL_DIR/job\"\n",
+    "JOBNAME= \"keras_mnist_$(date -u +%y%m%d_%H%M%S)\"\n",
+    "TRAIN_STEPS=1000\n",
+    "\n",
+    "os.environ['REGION'] = REGION\n",
+    "os.environ['TFVERSION'] = TFVERSION\n",
+    "os.environ['BUCKET'] = BUCKET\n",
+    "os.environ['DATA_DIR'] = DATA_DIR\n",
+    "os.environ['MODEL_DIR'] = MODEL_DIR\n",
+    "os.environ['MODEL_NAME'] = MODEL_NAME\n",
+    "os.environ['MODEL_VERSION'] = MODEL_VERSION\n",
+    "os.environ['JOBDIR'] = JOBDIR\n",
+    "os.environ['JOBNAME'] = JOBNAME\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the training job. Adjust train_steps as needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud ml-engine jobs submit training $JOBNAME \\\n",
+    "   --region=$REGION \\\n",
+    "   --module-name=trainer.main \\\n",
+    "   --package-path=\"$(pwd)/trainer\" \\\n",
+    "   --job-dir=$JOBDIR \\\n",
+    "   --staging-bucket=gs://$BUCKET \\\n",
+    "   --runtime-version=$TFVERSION \\\n",
+    "   -- \\\n",
+    "   --data_dir=gs://$BUCKET/$DATA_DIR \\\n",
+    "   --model_dir=gs://$BUCKET/$MODEL_DIR \\\n",
+    "   --export_dir=gs://$BUCKET/$MODEL_DIR \\\n",
+    "   --train_steps=$TRAIN_STEPS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export the model location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash --out MODEL_LOCATION\n",
+    "\n",
+    "MODEL_LOCATION=$(gsutil ls gs://$BUCKET/$MODEL_DIR/export | tail -1)\n",
+    "echo $MODEL_LOCATION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(MODEL_LOCATION)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the model in CMLE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud ml-engine models create $MODEL_NAME --regions $REGION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the versioned model with the model location"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud ml-engine versions create $MODEL_VERSION --model $MODEL_NAME --runtime-version $TFVERSION --origin $MODEL_LOCATION"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate sample data to test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json, codecs\n",
+    "import matplotlib.pyplot as plt\n",
+    "from tensorflow.examples.tutorials.mnist import input_data\n",
+    "\n",
+    "HEIGHT=28\n",
+    "WIDTH=28\n",
+    "\n",
+    "mnist = input_data.read_data_sets('mnist/data', one_hot=True, reshape=False)\n",
+    "IMGNO=5 #CHANGE THIS to get different images\n",
+    "jsondata = {'X': mnist.test.images[IMGNO].reshape(HEIGHT, WIDTH).tolist()}\n",
+    "json.dump(jsondata, codecs.open('test.json', 'w', encoding='utf-8'))\n",
+    "plt.imshow(mnist.test.images[IMGNO].reshape(HEIGHT, WIDTH));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gcloud ml-engine predict \\\n",
+    "   --model=$MODEL_NAME \\\n",
+    "   --version=$MODEL_VERSION \\\n",
+    "   --json-instances=./test.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Experimental/distributed_keras/mnist/Keras_MNIST_local.ipynb
+++ b/Experimental/distributed_keras/mnist/Keras_MNIST_local.ipynb
@@ -1,0 +1,355 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build and run a Keras model locally\n",
+    "\n",
+    "Assumes images have been preprocessed and converted to tfrecords<br/>\n",
+    "Converts Keras model to Estimator using model_to_estimator<br/>\n",
+    "Saves the model in GCS<br/>\n",
+    "Run prediction method (locally) from the saved model<br/>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "tf.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME=''\n",
+    "MODEL_NAME=''\n",
+    "TRAIN_STEPS=1000\n",
+    "BATCH_SIZE = 50\n",
+    "N_EPOCHS = 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the directories on GCS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import os\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "  ROOT_DIR = 'gs://{}'.format(BUCKET_NAME)\n",
+    "except NameError:\n",
+    "  ROOT_DIR = './tutorial'\n",
+    "  \n",
+    "DATA_DIR = '{}/data'.format(ROOT_DIR)\n",
+    "MODEL_DIR = '{}/{}'.format(ROOT_DIR, MODEL_NAME)\n",
+    "EXPORT_DIR = '{}/{}'.format(ROOT_DIR, MODEL_NAME)\n",
+    "CHECKPOINT_PATH = '{}/checkpoint'.format(MODEL_DIR)\n",
+    "\n",
+    "os.environ['BUCKET_NAME']=BUCKET_NAME\n",
+    "os.environ['MODEL_NAME']=MODEL_NAME\n",
+    "  \n",
+    "# Remove CHECKPOINT_DIR if needed\n",
+    "if tf.gfile.IsDirectory(MODEL_DIR):\n",
+    "  tf.logging.info('delete {}'.format(MODEL_DIR))\n",
+    "  tf.gfile.DeleteRecursively(MODEL_DIR)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Input function using tf.data.Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_input_fn(file_pattern, mode, batch_size=BATCH_SIZE, count=N_EPOCHS):\n",
+    "  \n",
+    "  def parse_record(serialized_example):\n",
+    "    features = tf.parse_single_example(\n",
+    "        serialized_example,\n",
+    "        features={\n",
+    "            'image': tf.FixedLenFeature([], tf.string),\n",
+    "            'label': tf.FixedLenFeature([], tf.string),            \n",
+    "        })\n",
+    "    # Normalize from [0, 255] to [0.0, 1.0]\n",
+    "    image = tf.decode_raw(features['image'], tf.uint8)\n",
+    "    image = tf.cast(image, tf.float32)\n",
+    "    image = tf.reshape(image, [28*28]) / 255.0\n",
+    "    label = tf.decode_raw(features['label'], tf.uint8)\n",
+    "    label = tf.reshape(label, [])\n",
+    "    label = tf.one_hot(label, 10, dtype=tf.int32)\n",
+    "    return image, label\n",
+    "\n",
+    "  def input_fn():\n",
+    "    files = tf.data.Dataset.list_files(file_pattern)\n",
+    "    dataset = tf.data.TFRecordDataset(files)\n",
+    "    \n",
+    "    if mode == tf.estimator.ModeKeys.TRAIN:\n",
+    "      dataset = dataset.cache()\n",
+    "      dataset = dataset.shuffle(10000)\n",
+    "      dataset = dataset.repeat(count=count)\n",
+    "      \n",
+    "    dataset = dataset.map(parse_record)\n",
+    "    dataset = dataset.batch(batch_size)\n",
+    "    \n",
+    "    iterator = dataset.make_one_shot_iterator()\n",
+    "    features, labels = iterator.get_next()\n",
+    "\n",
+    "    return features, labels\n",
+    "  \n",
+    "  return input_fn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build model and return the estimator and input_signature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_estimator(MODEL_DIR):\n",
+    "  model = tf.keras.Sequential()\n",
+    "  model.add(tf.keras.layers.Dense(300, activation='relu', input_shape=[28*28]))\n",
+    "  model.add(tf.keras.layers.Dense(100, activation='relu'))  \n",
+    "  model.add(tf.keras.layers.Dense(10, activation='softmax'))\n",
+    "  model.compile(loss='categorical_crossentropy',\n",
+    "                optimizer=tf.keras.optimizers.SGD(lr=0.005),\n",
+    "                metrics=['accuracy'])  \n",
+    "  estimator = tf.keras.estimator.model_to_estimator(\n",
+    "    model, model_dir=MODEL_DIR)\n",
+    "\n",
+    "  input_signature = model.input.name.split(':')[0]\n",
+    "  \n",
+    "  return estimator, input_signature\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Serving input function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_serving_input_fn(input_signature):\n",
+    "  def preprocess(x):\n",
+    "    return tf.reshape(x, [-1, 28*28]) / 255.0\n",
+    "\n",
+    "  def serving_input_fn():\n",
+    "    receiver_tensor = {'X': tf.placeholder(tf.float32, shape=[None, 28, 28])}\n",
+    "    features = {input_signature: tf.map_fn(preprocess, receiver_tensor['X'])}\n",
+    "    return tf.estimator.export.ServingInputReceiver(features, receiver_tensor)\n",
+    "  return serving_input_fn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Input functions for train, eval, and test datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_input_fn = generate_input_fn(\n",
+    "    file_pattern='{}/train.tfrecord'.format(DATA_DIR),\n",
+    "    mode=tf.estimator.ModeKeys.TRAIN,\n",
+    "    batch_size=BATCH_SIZE, count=N_EPOCHS)\n",
+    "\n",
+    "eval_input_fn = generate_input_fn(\n",
+    "    file_pattern='{}/eval.tfrecord'.format(DATA_DIR),\n",
+    "    mode=tf.estimator.ModeKeys.EVAL, count=1)\n",
+    "\n",
+    "test_input_fn = generate_input_fn(\n",
+    "    file_pattern='{}/test.tfrecord'.format(DATA_DIR),\n",
+    "    mode=tf.estimator.ModeKeys.PREDICT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the training and evaluation using the estimator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the estimator and input signature from the keras model conversion to tf.estimator\n",
+    "estimator, input_signature = get_estimator(MODEL_DIR)\n",
+    "\n",
+    "# exporter is invoked during evaluation\n",
+    "exporter = tf.estimator.LatestExporter(\n",
+    "    name='export',\n",
+    "    serving_input_receiver_fn=get_serving_input_fn(input_signature))\n",
+    "\n",
+    "train_spec = tf.estimator.TrainSpec(input_fn=train_input_fn, max_steps=TRAIN_STEPS)\n",
+    "\n",
+    "eval_spec = tf.estimator.EvalSpec(\n",
+    "    input_fn=eval_input_fn,\n",
+    "    steps=None,\n",
+    "    start_delay_secs=60,\n",
+    "    throttle_secs=60,\n",
+    "    exporters=exporter)\n",
+    "\n",
+    "# finally, train and evaluate\n",
+    "tf.estimator.train_and_evaluate(estimator, train_spec, eval_spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Show the model location and signature of the serving function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "\n",
+    "MODEL_LOCATION=$(gsutil ls gs://${BUCKET_NAME}/${MODEL_NAME}/export/ | tail -1)\n",
+    "echo \"export model location:\" ${MODEL_LOCATION}\n",
+    "\n",
+    "saved_model_cli show --dir ${MODEL_LOCATION} --tag_set serve --signature_def serving_default"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set the values for the export directory and output key"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the export model location\n",
+    "export_dir = \"\"\n",
+    "\n",
+    "#get the tensor output key, for example 'dense_3' from the above output\n",
+    "outputs_key=''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Predict with test data locally from the saved model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "N_EXAMPLES = 100\n",
+    "\n",
+    "train, test = tf.keras.datasets.mnist.load_data()\n",
+    "X_train = train[0][:-5000]\n",
+    "y_train = train[1][:-5000]\n",
+    "X_eval = train[0][-5000:]\n",
+    "y_eval = train[1][-5000:]\n",
+    "X_test = test[0]\n",
+    "y_test = test[1]\n",
+    "\n",
+    "predictor_fn = tf.contrib.predictor.from_saved_model(\n",
+    "  export_dir=export_dir, signature_def_key='serving_default')\n",
+    "\n",
+    "_X = X_test[:N_EXAMPLES]\n",
+    "_y = y_test[:N_EXAMPLES]\n",
+    "\n",
+    "output = predictor_fn({'X': _X})\n",
+    "class_ids = np.argmax(output[outputs_key], axis=2).reshape(-1)\n",
+    "\n",
+    "accuracy = np.sum(_y == class_ids)/float(N_EXAMPLES)\n",
+    "print(accuracy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Experimental/distributed_keras/mnist/README.md
+++ b/Experimental/distributed_keras/mnist/README.md
@@ -1,0 +1,11 @@
+# MNIST Keras Tutorial using Google Cloud Machine Learning Engine (CMLE)
+
+
+## These notebooks cover:
+* Preprocessing the dataset using Beam 
+* Run training locally
+* Convert the Keras model to TF Estimator
+* Run distributed training using CMLE
+* Deploying model to CMLE
+* Online prediction request using CMLE with a sample image 
+

--- a/Experimental/distributed_keras/mnist/preprocess_locally.ipynb
+++ b/Experimental/distributed_keras/mnist/preprocess_locally.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preprocess MNIST dataset (locally without Beam/Dataflow)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.8.0'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "tf.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set your bucket name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "BUCKET_NAME=''\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import os\n",
+    "\n",
+    "try:\n",
+    "  ROOT_DIR = 'gs://{}'.format(BUCKET_NAME)\n",
+    "except NameError:\n",
+    "  ROOT_DIR = './tutorial'\n",
+    "  \n",
+    "DATA_DIR = '{}/mnist-data'.format(ROOT_DIR)\n",
+    "\n",
+    "# Remove CHECKPOINT_DIR if needed\n",
+    "  \n",
+    "if not tf.gfile.IsDirectory(DATA_DIR):\n",
+    "  tf.logging.info('create {}'.format(DATA_DIR))\n",
+    "  tf.gfile.MkDir(ROOT_DIR)\n",
+    "  tf.gfile.MkDir(DATA_DIR)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Select a subset of records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "train, test = tf.keras.datasets.mnist.load_data()\n",
+    "X_train = train[0][:-5000]\n",
+    "y_train = train[1][:-5000]\n",
+    "X_eval = train[0][-5000:]\n",
+    "y_eval = train[1][-5000:]\n",
+    "X_test = test[0]\n",
+    "y_test = test[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert the dataset (image and labels) to tfrecords and store on Google Cloud Storage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _bytes_feature(value):\n",
+    "  return tf.train.Feature(bytes_list=tf.train.BytesList(value=[value]))\n",
+    "def _int64_feature(value):\n",
+    "  return tf.train.Feature(int64_list=tf.train.Int64List(value=[value]))\n",
+    "\n",
+    "def create_example(image, label):  \n",
+    "  feature={\n",
+    "      'image': _bytes_feature(image.tobytes()),\n",
+    "      'label': _bytes_feature(label.tobytes())}\n",
+    "  return tf.train.Example(features=tf.train.Features(feature=feature))\n",
+    "\n",
+    "def convert_to_tfrecord(images, labels, output_file):\n",
+    "  with tf.python_io.TFRecordWriter(output_file) as record_writer:\n",
+    "    for image, label in zip(images, labels):\n",
+    "      example = create_example(image, label)\n",
+    "      record_writer.write(example.SerializeToString())\n",
+    "      \n",
+    "      \n",
+    "convert_to_tfrecord(X_train, y_train,\n",
+    "                    output_file='{}/train.tfrecord'.format(DATA_DIR))\n",
+    "convert_to_tfrecord(X_eval, y_eval,\n",
+    "                    output_file='{}/eval.tfrecord'.format(DATA_DIR))\n",
+    "convert_to_tfrecord(X_test, y_test,\n",
+    "                    output_file='{}/test.tfrecord'.format(DATA_DIR))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Experimental/distributed_keras/mnist/trainer/main.py
+++ b/Experimental/distributed_keras/mnist/trainer/main.py
@@ -1,0 +1,129 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import sys
+
+import tensorflow as tf
+
+# Model specific parameters
+tf.flags.DEFINE_string(
+    "data_dir", default="gs://your-bucket-name/keras-mnist/data",
+    help="Path to directory containing the MNIST dataset")
+tf.flags.DEFINE_string(
+    "model_dir", default="gs://your-bucket-name/keras-mnist/keras-model",
+    help="Estimator model_dir")
+tf.flags.DEFINE_integer(
+    "batch_size", default=100,
+    help="Mini-batch size for the training. Note that this is the global batch "
+    "size and not the per-shard batch.")
+tf.flags.DEFINE_float(
+    "learning_rate", default=0.005,
+    help="Learning rate used to optimize your model.")
+tf.flags.DEFINE_integer(
+    "train_steps", default=1000,
+    help="Total number of training steps.")
+tf.flags.DEFINE_string(
+    "export_dir", default="gs://your-bucket-name/keras-mnist/keras-model/export",
+    help="The directory where the exported SavedModel will be stored.")
+
+FLAGS = tf.flags.FLAGS
+
+
+def get_estimator():
+  model = tf.keras.Sequential()
+  model.add(tf.keras.layers.Dense(300, activation='relu', input_shape=[28*28]))
+  model.add(tf.keras.layers.Dense(100, activation='relu'))  
+  model.add(tf.keras.layers.Dense(10, activation='softmax'))
+  model.compile(loss='categorical_crossentropy',
+                optimizer=tf.keras.optimizers.SGD(lr=0.005),
+                metrics=['accuracy'])  
+  estimator = tf.keras.estimator.model_to_estimator(
+    model, model_dir=FLAGS.model_dir)
+
+  input_signature = model.input.name.split(':')[0]
+  return estimator, input_signature
+
+def get_serving_input_fn(input_signature):
+  def preprocess(x):
+    return tf.reshape(x, [-1, 28*28]) / 255.0
+
+  def serving_input_fn():
+    receiver_tensor = {'X': tf.placeholder(tf.float32, shape=[None, 28, 28])}
+    features = {input_signature: tf.map_fn(preprocess, receiver_tensor['X'])}
+    return tf.estimator.export.ServingInputReceiver(features, receiver_tensor)
+  return serving_input_fn
+
+def generate_input_fn(file_pattern, mode, batch_size, count=None):
+  def parse_record(serialized_example):
+    features = tf.parse_single_example(
+        serialized_example,
+        features={
+            'image': tf.FixedLenFeature([], tf.string),
+            'label': tf.FixedLenFeature([], tf.string),            
+        })
+    # Normalize from [0, 255] to [0.0, 1.0]
+    image = tf.decode_raw(features['image'], tf.uint8)
+    image = tf.cast(image, tf.float32)
+    image = tf.reshape(image, [28*28]) / 255.0
+    label = tf.decode_raw(features['label'], tf.uint8)
+    label = tf.reshape(label, [])
+    label = tf.one_hot(label, 10, dtype=tf.int32)
+    return image, label
+
+  def input_fn():
+    files = tf.data.Dataset.list_files(file_pattern)
+    dataset = tf.data.TFRecordDataset(files)
+    
+    if mode == tf.estimator.ModeKeys.TRAIN:
+      dataset = dataset.cache()
+      dataset = dataset.shuffle(1000)
+      dataset = dataset.repeat(count=count)
+      
+    dataset = dataset.map(parse_record)
+    dataset = dataset.batch(batch_size)
+    
+    iterator = dataset.make_one_shot_iterator()
+    features, labels = iterator.get_next()
+
+    return features, labels
+  
+  return input_fn
+
+def main(unused_argv):
+  tf.logging.set_verbosity(tf.logging.INFO)
+
+  estimator, input_signature = get_estimator()
+  train_input_fn = generate_input_fn(
+    file_pattern='{}/train.tfrecord'.format(FLAGS.data_dir),
+    mode=tf.estimator.ModeKeys.TRAIN,
+    batch_size=FLAGS.batch_size, count=None)
+
+  eval_input_fn = generate_input_fn(
+    file_pattern='{}/eval.tfrecord'.format(FLAGS.data_dir),
+    mode=tf.estimator.ModeKeys.EVAL,
+    batch_size=FLAGS.batch_size, count=None)
+
+  test_input_fn = generate_input_fn(
+    file_pattern='{}/test.tfrecord'.format(FLAGS.data_dir),
+    mode=tf.estimator.ModeKeys.PREDICT,
+    batch_size=FLAGS.batch_size, count=None)
+
+  train_spec = tf.estimator.TrainSpec(input_fn=train_input_fn, max_steps=FLAGS.train_steps)
+
+  exporter = tf.estimator.LatestExporter(
+    name='export',
+    serving_input_receiver_fn=get_serving_input_fn(input_signature))
+
+  eval_spec = tf.estimator.EvalSpec(
+    input_fn=eval_input_fn,
+    steps=None,
+    start_delay_secs=60,
+    throttle_secs=60,
+    exporters=exporter)
+
+  tf.estimator.train_and_evaluate(estimator, train_spec, eval_spec)
+
+if __name__ == "__main__":
+  tf.app.run()


### PR DESCRIPTION
This pull request covers some refactoring of the distributed_keras folder by adding a subfolder for mnist with the idea that we can have multiple subfolders under distributed_keras for different ML problems. The pull request enables the user to do the following:

- run all the pipeline/code through notebooks
- deploy the model to CMLE
- generate a sample image that can be displayed inline
- and use that image to perform an online prediction request on the deployed model 